### PR TITLE
feat!: improve synchornization bandwidth and entity open logic.

### DIFF
--- a/change/@muni-town-leaf-b599460a-35e4-420a-8c2f-e88bbcd859c3.json
+++ b/change/@muni-town-leaf-b599460a-35e4-420a-8c2f-e88bbcd859c3.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat!: improve synchornization bandwidth and entity open logic.",
+  "packageName": "@muni-town/leaf",
+  "email": "zicklag@katharostech.com",
+  "dependentChangeType": "prerelease"
+}

--- a/change/@muni-town-leaf-svelte-2d499900-c7d4-4887-b851-038f530f56f3.json
+++ b/change/@muni-town-leaf-svelte-2d499900-c7d4-4887-b851-038f530f56f3.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat!: improve synchornization bandwidth and entity open logic.",
+  "packageName": "@muni-town/leaf-svelte",
+  "email": "zicklag@katharostech.com",
+  "dependentChangeType": "prerelease"
+}

--- a/packages/leaf-svelte/src/index.ts
+++ b/packages/leaf-svelte/src/index.ts
@@ -1,10 +1,10 @@
 /**
  * A svelte reactivity integration for Leaf. See {@linkcode SveltePeer} for usage.
- * 
+ *
  * @module @muni-town/leaf-svelte
  */
 
-import { type Entity, type IntoEntityId, Peer, type PeerOpenOptions } from "@muni-town/leaf";
+import { type Entity, type IntoEntityId, Peer, PeerOpenOptions } from "@muni-town/leaf";
 import { createSubscriber } from "svelte/reactivity";
 
 /**
@@ -19,11 +19,17 @@ import { createSubscriber } from "svelte/reactivity";
 export class SveltePeer extends Peer {
   // Override the entity open function
   override async open(
-    id?: IntoEntityId,
-    opts?: Partial<PeerOpenOptions>
+    id: IntoEntityId,
+    options?: Partial<PeerOpenOptions>,
   ): Promise<Entity> {
     // Get the entity like normal
-    const entity = await super.open(id, opts);
+    const entity = await super.open(id, options);
+    // And wrap it in a reactive entity
+    return reactiveEntity(entity);
+  }
+  override async create(): Promise<Entity> {
+    // Get the entity like normal
+    const entity = await super.create();
     // And wrap it in a reactive entity
     return reactiveEntity(entity);
   }

--- a/packages/leaf/src/index.ts
+++ b/packages/leaf/src/index.ts
@@ -484,22 +484,15 @@ export type StorageConfig = {
 export type PeerOption = StorageManager | Syncer1 | StorageConfig;
 
 /**
- * Options for configuring {@linkcode Peer.open}.
- *
- * @see defaultPeerOpenOptions;
+ * Options for configuring {@linkcode Peer["open"]}.
  */
 export type PeerOpenOptions = {
-  /** Whether when opening the entity we should wait to return until we have gotten an update from
-   * one of our syncers, or else the `awaitSyncTimeout` passes. */
-  awaitSync: boolean;
-  /** The amount of time we should wait for a peer to sync us an update before just continuing when
-   * `awaitSync` is `true`. */
-  awaitSyncTimeout: number;
-};
-/** Default {@linkcode PeerOpenOptions}. */
-export const defaultPeerOpenOptions = {
-  awaitSync: true,
-  awaitSyncTimeout: 1000,
+  /**
+   * If set, when opening an entity that does not exist locally, and cannot be synced from a peer,
+   * the function will wait the specified number of milliseconds before creating the entity and
+   * returning the newly created entity.
+   * */
+  createAfterTimeout: number;
 };
 
 /**
@@ -510,7 +503,7 @@ export class Peer {
   #syncers: Syncer1[] = [];
   #storages: StorageConfig[] = [];
   #storageUnsubscribers: Map<EntityIdStr, () => void> = new Map();
-  #entities: Map<EntityIdStr, WeakRef<Entity>> = new Map();
+  #entities: Map<EntityIdStr, Promise<WeakRef<Entity>>> = new Map();
   #finalizationRegistry: FinalizationRegistry<EntityIdStr>;
 
   constructor(...options: PeerOption[]) {
@@ -533,29 +526,60 @@ export class Peer {
    *
    * This will try to load the entity from all read storages and await on that before returning.
    *
+   * If the entity is not found the promise will remain pending.
+   *
    * It will also start syncing the entity with all of the peer's syncers.
    * */
   async open(
+    id: IntoEntityId,
+    options?: Partial<PeerOpenOptions>
+  ): Promise<Entity> {
+    // console.debug("calling open", intoEntityId(id).toString(), options);
+    return this.#open_raw(id, options);
+  }
+
+  async create(): Promise<Entity> {
+    // console.debug("calling create");
+    const entity = this.#open_raw();
+    // console.debug("created", (await entity).id.toString());
+    return entity;
+  }
+
+  async #open_raw(
     id?: IntoEntityId,
     opts?: Partial<PeerOpenOptions>
   ): Promise<Entity> {
-    const options = { ...defaultPeerOpenOptions, ...(opts || {}) };
+    const options = { ...(opts || {}) };
 
     const entId = id ? intoEntityId(id) : new EntityId();
+    // console.debug("opening raw", entId.toString(), options);
     const entIdStr = entId.toString();
 
-    const existingEnt = this.#entities.get(entIdStr)?.deref();
-    if (existingEnt) return existingEnt;
+    const existingEntPromise = this.#entities.get(entIdStr);
+    if (existingEntPromise) {
+      const weakExistingEnt = await existingEntPromise;
+      const existingEnt = weakExistingEnt.deref();
+      if (existingEnt) {
+        // console.debug("Already open", entId.toString());
+        return existingEnt;
+      } else {
+        this.#entities.delete(entIdStr);
+      }
+    }
 
     const entity = new Entity(entId);
     const weakEntity = new WeakRef(entity);
     this.#finalizationRegistry.register(entity, entIdStr, weakEntity);
-    this.#entities.set(entIdStr, weakEntity);
+    let resolveWeakEntity: (e: WeakRef<Entity>) => void = () => {};
+    this.#entities.set(entIdStr, new Promise((r) => (resolveWeakEntity = r)));
+
+    let loadedLocal = id ? false : true; // We've already "loaded" the entity locally if we just created it
     for (const storage of this.#storages) {
       if (storage.read !== false) {
-        await storage.manager.load(entity);
+        loadedLocal = loadedLocal || (await storage.manager.load(entity));
       }
     }
+
     for (const syncer of this.#syncers) {
       // TODO: We need to make sure the syncer only holds a weak reference to the entity so that we
       // can detect when it's no longer needed and can be closed.
@@ -583,32 +607,49 @@ export class Peer {
     });
     this.#storageUnsubscribers.set(entIdStr, unsubscribeStorage);
 
-    if (options.awaitSync) {
+    if (!loadedLocal) {
       let stopTimeout: () => void = () => {};
 
-      // Finish with the first to complete
-      await Promise.race([
-        // Wait until all syncers have responded with their latest data for the entity
-        (async () => {
-          await Promise.all(
-            this.#syncers.map(
-              (syncer) => syncer.syncing.get(entIdStr)?.awaitInitialLoad
-            )
-          );
-          stopTimeout();
-        })(),
-
-        // Just timeout if we don't get a response in time
-        new Promise((r) => {
-          const n = setTimeout(r, options.awaitSyncTimeout);
+      // Just timeout if we don't get a response in time
+      const timeoutPromise =
+        options.createAfterTimeout &&
+        new Promise<void>((r) => {
+          const n = setTimeout(r, options.createAfterTimeout);
           stopTimeout = () => {
             r(undefined);
             clearTimeout(n);
           };
-        }),
-      ]);
+        });
+
+      const race = [
+        // Wait until a syncer has responded with their latest data for the entity
+        (async () => {
+          const promises = this.#syncers.map((syncer) =>
+            (async () => {
+              // console.log("staring sync", entId.toString());
+              await syncer.syncing.get(entIdStr)?.awaitInitialLoad;
+              // console.log("done syncing", entId);
+              return;
+            })()
+          );
+          await Promise.race(promises);
+          stopTimeout();
+        })(),
+      ];
+      if (timeoutPromise) race.push(timeoutPromise);
+
+      // Finish with the first to complete
+      await Promise.race(race);
+    } else {
+      // console.debug("loaded local", entId.toString());
     }
 
+    resolveWeakEntity(weakEntity);
+    // console.debug(
+    //   "returning entity ",
+    //   entId.toString(),
+    //   entity.doc.changeCount()
+    // );
     return entity;
   }
 
@@ -649,12 +690,12 @@ export class Peer {
       // network / storage synchronization has not been finished yet. So we queue the actual cleanup
       // of the entity until _after_ the other callbacks have run, with queueMicrotask, so that the
       // caller can wait for the entity to actually finish getting persisted.
-      queueMicrotask(() => {
+      queueMicrotask(async () => {
         if (this) {
           const entId = id ? intoEntityId(id) : new EntityId();
           const entIdStr = entId.toString();
 
-          const entity = this.#entities.get(entIdStr)?.deref();
+          const entity = (await this.#entities.get(entIdStr))?.deref();
 
           if (entity) {
             // This will trigger a write to storage

--- a/packages/leaf/src/sync-proto.ts
+++ b/packages/leaf/src/sync-proto.ts
@@ -48,7 +48,7 @@ export class Sync1BinaryWrapper implements Sync1Interface {
 
   subscribe(
     entityId: EntityIdStr,
-    snapshot: Uint8Array,
+    versionVector: Uint8Array,
     handleUpdate: Subscriber
   ): () => void {
     const subs = getOrDefault(this.#subscribers, entityId, []);
@@ -57,7 +57,7 @@ export class Sync1BinaryWrapper implements Sync1Interface {
     this.#binaryInterface.send(
       encodeClientMessage({
         type: "subscribe",
-        snapshot,
+        versionVector,
         entityId,
       })
     );
@@ -106,7 +106,7 @@ export class SuperPeer1BinaryWrapper implements Sync1BinaryInterface {
     } else if (data.type == "subscribe") {
       const unsubscribe = this.#superPeer.subscribe(
         data.entityId,
-        data.snapshot,
+        data.versionVector,
         (entityId, update) => {
           this.#receiver(
             encodeServerResponse({
@@ -146,7 +146,7 @@ export const clientMessage = type({
   .or({
     type: "'subscribe'",
     entityId: "string" as type.cast<EntityIdStr>,
-    snapshot: type.instanceOf(Uint8Array<ArrayBufferLike>),
+    versionVector: type.instanceOf(Uint8Array<ArrayBufferLike>),
   })
   .or({
     type: "'sendUpdate'",

--- a/packages/leaf/src/sync1.ts
+++ b/packages/leaf/src/sync1.ts
@@ -11,10 +11,12 @@
  */
 
 import {
+  decodeImportBlobMeta,
   Entity,
   type EntityIdStr,
   LoroDoc,
   type StorageConfig,
+  VersionVector,
 } from "./index.ts";
 import { StorageManager } from "./storage.ts";
 import { getOrDefault } from "./utils.ts";
@@ -144,12 +146,24 @@ export class Syncer1 {
     // Subscribe to updates from the network and send our latest snapshot
     const unsubscribeNet = this.inter.subscribe(
       id,
-      ent.doc.export({ mode: "snapshot" }),
+      ent.doc.version().encode(),
       (_id, update) => {
-        initialLoaded();
         const ent = entity.deref();
         if (ent) {
           ent.doc.import(update);
+          initialLoaded();
+
+          // Check to see if we have versions that aren't present on the sync peer
+          const newVersionVector = ent.doc.version();
+          const { partialEndVersionVector: importVersionVector } =
+            decodeImportBlobMeta(update, false);
+          if (importVersionVector.compare(newVersionVector) !== 0) {
+            // Send an update with the commits we have that they don't have
+            this.inter.sendUpdate(
+              id,
+              ent.doc.export({ mode: "update", from: importVersionVector })
+            );
+          }
         } else {
           this.unsync(id);
         }
@@ -261,71 +275,80 @@ export class SuperPeer1 implements Sync1Interface {
 
   subscribe(
     entityId: EntityIdStr,
-    snapshot: Uint8Array,
+    versionVector: Uint8Array | undefined,
     handleUpdate: Subscriber
   ): () => void {
+    // Trigger an async task
     (async () => {
       try {
-        const incomingEnt = new Entity(entityId);
-        incomingEnt.doc.import(snapshot);
-
-        const ent = new Entity(entityId);
-        for (const storage of this.#storages) {
-          if (storage.read !== false) {
-            await storage.manager.load(ent);
-          }
+        // Try to parse the incoming entity version if specified
+        let incomingVersion: VersionVector | undefined;
+        try {
+          incomingVersion =
+            versionVector && VersionVector.decode(versionVector);
+        } catch (e) {
+          console.trace(
+            "Invalid version vector provided when subscribing to entity.",
+            e
+          );
         }
-        const currentFrontiers = ent.doc.frontiers();
-        ent.doc.import(snapshot);
-        const newFrontiers = ent.doc.frontiers();
 
-        // If the sync gave us new data
-        const cmp = ent.doc.cmpFrontiers(currentFrontiers, newFrontiers);
-        if (cmp === -1 || cmp === undefined) {
-          // Update storage
+        // Load the requested entity from local storage
+        const ent = new Entity(entityId);
+        let loaded = false;
+
+        try {
           for (const storage of this.#storages) {
-            if (storage.write !== false) {
-              // TODO: consider **not** awaiting this.
-              // If we don't we need to catch possible exceptions and prevent it from
-              // crashing the runtime if there's an error. Awaiting it allows the caller
-              // to handle the exception which is probably desirable, but not awaiting it
-              // allows us to move on and not wait for storage to finish before syncing
-              // to subscribers which may be desirable.
-              await storage.manager.save(ent);
+            if (storage.read !== false) {
+              loaded = (await storage.manager.load(ent)) || loaded;
             }
           }
+        } catch (e) {
+          console.trace("Error loading entity from storage", e);
+        }
 
-          // And sync it to all subscribers
-          const subscriberUpdate = ent.doc.export({
-            mode: "update",
-            from: ent.doc.frontiersToVV(currentFrontiers),
-          });
-          for (const sub of getOrDefault(this.#subscribers, entityId, [])) {
-            sub(entityId, subscriberUpdate);
+        // If we had the entity locally
+        if (loaded) {
+          // If the client specified a version of the entity that they currently have locally
+          if (incomingVersion) {
+            // Return the updates that the peer didn't already have.
+            handleUpdate(
+              entityId,
+              ent.doc.export({
+                mode: "update",
+                from: incomingVersion,
+              })
+            );
+
+            // If the client doesn't have any data for this entity yet
+          } else {
+            // Return a complete snapshot of the entity
+            handleUpdate(entityId, ent.doc.export({ mode: "snapshot" }));
           }
         }
 
-        // Return the updates that the peer didn't already have.
-        handleUpdate(
-          entityId,
-          ent.doc.export({ mode: "update", from: incomingEnt.doc.version() })
-        );
+        // Free memory
         ent.free();
-        incomingEnt.free();
+        incomingVersion && incomingVersion.free();
       } catch (e) {
         console.error(new Error(`Error syncing snapshots: ${e}`));
       }
     })();
 
+    // Add the client's `handleUpdate` function to our list of subscribers
     const subs = getOrDefault(this.#subscribers, entityId, []);
     subs.push(handleUpdate);
 
+    // Return the unsubscribe function that can be used to stop us from calling the client's
+    // `handleUpdate` function every time the entity changes.
     return () => {
       const subs = getOrDefault(this.#subscribers, entityId, []);
-      this.#subscribers.set(
-        entityId,
-        subs.filter((x) => x !== handleUpdate)
-      );
+      const newSubs = subs.filter((x) => x !== handleUpdate);
+      if (newSubs.length > 0) {
+        this.#subscribers.set(entityId, newSubs);
+      } else {
+        this.#subscribers.delete(entityId);
+      }
     };
   }
 
@@ -333,12 +356,10 @@ export class SuperPeer1 implements Sync1Interface {
     (async () => {
       try {
         const ent = new Entity(entityId);
-        let n = 0;
         // Load ent from storage
         for (const storage of this.#storages) {
           if (storage.read !== false) {
             await storage.manager.load(ent);
-            n += 1;
           }
         }
         const currentFrontiers = ent.doc.frontiers();


### PR DESCRIPTION
This fixes a lot of issues:

- Opening an entity assumes that it should exist locally or come from a sync peer and will wait for sync or local load to return by default.
- Opening an entity that you have locally returns immediately after loading from local storage instead of waiting for sync.
- Opening an entity while it is already open also works as expected with the new features above, preventing unnecessary loads.
- The sync protocol no longer pushes an entire snapshot of the local entities when syncing them. It will send the local version vector and wait to see if the server has a relatively out-of-date version before sending the local snapshot. This is work-in-progress, needs more work, and still unnecessary data at the very least by receiving it's own updates back from the syncserver. There are probably more fixes needed.